### PR TITLE
Add Error Handler Method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 .vscode
 dist
-coverage
-.nyc_outputs
+.nyc_output
+respondex-[0-9]*.tgz

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RespondEx [![Build Status](https://travis-ci.org/IyiKuyoro/RespondEx.svg?branch=develop)](https://travis-ci.org/IyiKuyoro/RespondEx) [![Coverage Status](https://coveralls.io/repos/github/IyiKuyoro/RespondEx/badge.svg?branch=develop)](https://coveralls.io/github/IyiKuyoro/RespondEx?branch=develop) [![Maintainability](https://api.codeclimate.com/v1/badges/aefd9dedd80b68dd6212/maintainability)](https://codeclimate.com/github/IyiKuyoro/RespondEx/maintainability) [![npm version](https://badge.fury.io/js/respondex.svg)](https://badge.fury.io/js/respondex)
+# @respondex/core [![Build Status](https://travis-ci.org/IyiKuyoro/RespondEx.svg?branch=develop)](https://travis-ci.org/IyiKuyoro/RespondEx) [![Coverage Status](https://coveralls.io/repos/github/IyiKuyoro/RespondEx/badge.svg?branch=develop)](https://coveralls.io/github/IyiKuyoro/RespondEx?branch=develop) [![Maintainability](https://api.codeclimate.com/v1/badges/aefd9dedd80b68dd6212/maintainability)](https://codeclimate.com/github/IyiKuyoro/RespondEx/maintainability)
 
 This is a simple node package that helps developers package HTTP responses into simple reusable methods, without having to worry about setting the headers and the right status codes.
 
@@ -7,16 +7,16 @@ All you need to do is call the right method with all the information required al
 [Express](https://expressjs.com/) is a powerful framework that helps handle HTTP requests and responses on the server. However, it can become a bit repetitive to have to respond to various request the same way. This would help take all that repetitive "res" code and stow it away in the node_modules. 😄
 
 ## Getting Started
-Your REST API must be using [express](https://expressjs.com/) as its HTTP http handler.
-- Download the package as a dev dependency with 
+Your REST API must be using [express](https://expressjs.com/) as its HTTP handler.
+- Download the package as a development dependency with 
 ```
-npm install respondex
+npm install @respondex/core @respondex/apierror
 ```
 - Import the package into your controller, middleware or wherever you wish to send a response from.
 ```
-import RespondEx from 'respondex'
+import RespondEx from '@respondex/core'
 ```
-- Use by simply send a response as demonstrated below for a newly created product resource.
+- Use by simply sending a response as demonstrated below for a newly created product resource.
 ```
 RespondEx.createdResource(
   'Successful sign-in',
@@ -34,13 +34,64 @@ RespondEx.createdResource(
 ### Methods
 **createdResource**: Sends a HTTP response for a newly created resource. Response will contain a 201 status code, message and data in the body. It would also contain the URL to the newly created resource in the header of the response.
 
-| Parameters | Type   | Description                              | Example                                       |
-|------------|--------|------------------------------------------|-----------------------------------------------|
-| message    | string | The message to be sent with the response | "Product successfully created."               |
-| data       | object | Newly created resource data              | { name: "Chair" }                             |
-| location   | string | The URL of the newly created resource    | "https://fakeecommerce.com/api/v1/products/1" |
-| res        | object | The express http response object         |                                               |
-| options    | object | Some extra headers                       | { contentType: "application/json" }           |
+| Parameters             | Type   | Description                              | Example                                       |
+|------------------------|--------|------------------------------------------|-----------------------------------------------|
+| message                | string | The message to be sent with the response | "Product successfully created."               |
+| data                   | object | Newly created resource data              | { name: "Chair" }                             |
+| location               | string | The URL of the newly created resource    | "https://fakeecommerce.com/api/v1/products/1" |
+| res                    | object | The express http response object         |                                               |
+| options (_optional_)   | object | Some extra headers                       | { contentType: "application/json" }           |
+
+#### Example
+```
+RespondEx.createdResource(
+  'Successful sign-in',
+  {
+    name: 'Chair',
+    quantity: 100,
+    description: 'A comfortable seat for your afternoon tea.'
+  },
+  'https://fakeecommerce.com/api/v1/products/1',
+  res,
+);
+```
+
+**error**: Sends a HTTP response error using an instance of the APIError class.
+
+| Parameter             | Type     | Description                              | Example                                       |
+|------------------------|----------|------------------------------------------|-----------------------------------------------|
+| error                  | APIError | An instance of the APIError object       |                                               |
+| res                    | object   | The express http response object         |                                               |
+| options (_optional_)   | object   | Some extra headers                       | { contentType: "application/json" }           |
+
+#### Example
+```
+import APIError from "@respondex/apierror"
+
+const error = new APIError(...);
+RespondEx.error(
+  error,
+  res,
+);
+```
+
+**errorByType**: Sends a HTTP response error by providing an error type.
+
+| Parameter                | Type     | Description                              | Example                                       |
+|---------------------------|----------|------------------------------------------|-----------------------------------------------|
+| type                      | string   | The type of error to be sent             | NotFound                                      |
+| res                       | object   | The express http response object         |                                               |
+| message (_optional_)      | object   | The message to be sent in the body       | "Some error has occurred"                     |
+| possibleErrors (_optional_)| object[]| The express http response object         |                                               |
+| options (_optional_)      | object   | Some extra headers                       | { contentType: "application/json" }           |
+
+#### Example
+```
+RespondEx.errorByType(
+  'NotFound',
+  res,
+);
+```
 
 ### Options
 This is an optional parameter that can be provided to the methods to configure some of the information in the header. Currently there is just one.
@@ -48,6 +99,17 @@ This is an optional parameter that can be provided to the methods to configure s
 | Property    | Type   | Example            |
 |-------------|--------|--------------------|
 | contentType | string | "application/json" |
+
+### Errors
+This is the list of error types
+
+| Error        | code | Description                     |
+|--------------|------|---------------------------------|
+| ClientError  | 400  | For general client errors       |
+| Unauth­orized | 401  | For unauthorized access errors  |
+| Forbidden    | 403  | For for forbidden access errors |
+| NotFound     | 404  | Resource not found error        |
+| _default_    | 500  | For general server errors       |
 
 ### Contributors
 _Opeoluwa Iyi-Kuyoro_: 👨🏿[Profile](https://github.com/IyiKuyoro) - [WebSite](https://iyikuyoro.com)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "respondex",
-  "version": "0.0.4",
+  "name": "@respondex/core",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -928,6 +928,14 @@
         "slash": "^2.0.0",
         "source-map": "^0.6.0",
         "string-length": "^2.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@jest/source-map": {
@@ -939,6 +947,14 @@
         "callsites": "^3.0.0",
         "graceful-fs": "^4.1.15",
         "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@jest/test-result": {
@@ -985,6 +1001,14 @@
         "slash": "^2.0.0",
         "source-map": "^0.6.1",
         "write-file-atomic": "2.4.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@jest/types": {
@@ -996,6 +1020,11 @@
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/yargs": "^12.0.9"
       }
+    },
+    "@respondex/apierror": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@respondex/apierror/-/apierror-0.0.1.tgz",
+      "integrity": "sha512-aNcsdxkNiopgTnQCNZYXZfgkKHTjHRRdtdGC1V9fHz8N0QNtfDGC7V9lYzblEvHbsanVJFZoMLQ+HKDUIrRdHQ=="
     },
     "@types/babel__core": {
       "version": "7.1.1",
@@ -2212,6 +2241,13 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2893,25 +2929,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2921,13 +2961,15 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2937,37 +2979,43 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2976,25 +3024,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3003,13 +3055,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3025,7 +3079,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3039,13 +3094,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3054,7 +3111,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3063,7 +3121,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3073,19 +3132,22 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3094,13 +3156,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3109,13 +3173,15 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3125,7 +3191,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3134,7 +3201,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3143,13 +3211,15 @@
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3160,7 +3230,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3178,7 +3249,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3188,13 +3260,15 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3204,7 +3278,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3216,19 +3291,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3237,19 +3315,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3259,19 +3340,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3283,7 +3367,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -3291,7 +3376,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3306,7 +3392,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3315,43 +3402,50 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3362,7 +3456,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3371,7 +3466,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3380,13 +3476,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3401,13 +3499,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3416,13 +3516,15 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true
         }
@@ -3550,6 +3652,14 @@
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "har-schema": {
@@ -4179,6 +4289,14 @@
         "make-dir": "^2.1.0",
         "rimraf": "^2.6.2",
         "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "istanbul-reports": {
@@ -4554,6 +4672,14 @@
         "mkdirp": "^0.5.1",
         "slash": "^2.0.0",
         "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "jest-validate": {
@@ -4932,6 +5058,14 @@
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "merge-stream": {
@@ -6283,12 +6417,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         }
       }
     },
@@ -6364,9 +6492,9 @@
       }
     },
     "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "source-map-resolve": {
@@ -6390,6 +6518,14 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "source-map-url": {
@@ -6878,14 +7014,23 @@
       }
     },
     "uglify-js": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
-      "integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.6.tgz",
+      "integrity": "sha512-YDKRX8F0Y+Jr7LhoVk0n4G7ltR3Y7qFAj+DtVBthlOgCcIj1hyMigCfousVfn9HKmvJ+qiFlLDwaHx44/e5ZKw==",
       "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.20.0",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "respondex",
-  "version": "0.0.5",
+  "name": "@respondex/core",
+  "version": "0.0.1",
   "description": "A package to handle express HTTP responses",
   "main": "./dist/index.js",
   "files": [
@@ -12,8 +12,8 @@
     "clean": "rm -rf dist",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint --fix ./src",
-    "prepublish": "npm run clean && mkdir dist && babel src -d dist --ignore src/**/__tests__/*.js,src/**/__mocks__/*.js",
-    "test": "jest"
+    "prepare": "npm run clean && mkdir dist && babel src -d dist --ignore src/**/__tests__/*.js,src/**/__mocks__/*.js",
+    "test": "npm run lint && jest"
   },
   "repository": {
     "type": "git",
@@ -33,7 +33,9 @@
     "jest": "^24.7.1",
     "nyc": "^14.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@respondex/apierror": "0.0.1"
+  },
   "commitplease": {
     "style": "angular",
     "types": [
@@ -47,5 +49,9 @@
       "chore"
     ],
     "scope": "\\S+.*"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/IyiKuyoro/RespondEx/issues"
+  },
+  "homepage": "https://github.com/IyiKuyoro/RespondEx#readme"
 }

--- a/src/__tests__/RespondEx.spec.js
+++ b/src/__tests__/RespondEx.spec.js
@@ -1,4 +1,5 @@
 import RespondEx from '..';
+import ApiError from '@respondex/apierror';
 import ResMock from '../__mocks__/ResMock';
 
 describe('RespondEx', () => {
@@ -58,6 +59,348 @@ describe('RespondEx', () => {
           number: 100,
           description: 'A comfortable chair for your afternoon tea',
         },
+      });
+    });
+  });
+
+  describe('error', () => {
+    let res;
+    let statusSpy;
+    let jsonSpy;
+    let setSpy;
+
+    beforeEach(() => {
+      res = new ResMock();
+      statusSpy = jest.spyOn(res, 'status');
+      jsonSpy = jest.spyOn(res, 'json');
+      setSpy = jest.spyOn(res, 'set');
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should set the response type to application/json', () => {
+      const error = new ApiError('Some error', [], 400);
+
+      RespondEx.error(error, res);
+
+      expect(setSpy).toHaveBeenCalledWith({
+        'content-type': 'application/json',
+      });
+    });
+
+    it('should set the status code to 400', () => {
+      const error = new ApiError('Some error', ['error'], 400);
+
+      RespondEx.error(error, res);
+
+      expect(statusSpy).toHaveBeenCalledWith(400);
+      expect(jsonSpy).toHaveBeenCalledWith({
+        success: false,
+        message: 'Some error',
+        possibleCauses: ['error'],
+      });
+    });
+
+    it('should set the status code to 500 with custom possible cases', () => {
+      const error = new ApiError('Some error');
+
+      RespondEx.error(error, res);
+
+      expect(statusSpy).toHaveBeenCalledWith(500);
+      expect(jsonSpy).toHaveBeenCalledWith({
+        success: false,
+        message: 'Some error',
+        possibleCauses: [],
+      });
+    });
+  });
+
+  describe('errorByType', () => {
+    describe('ClientError', () => {
+      let res;
+      let respondexSpy;
+
+      beforeEach(() => {
+        res = new ResMock();
+        respondexSpy = jest.spyOn(RespondEx, 'error')
+          .mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+      });
+
+      it('should call RespondEx.error with default message', () => {
+        RespondEx.errorByType(
+          'ClientError',
+          res,
+        );
+
+        const error = new ApiError(
+          'A client error has occurred.',
+          [
+            'You may not be sending all the information required',
+            'Some of the information may be in the wrong type or format',
+          ],
+          400,
+        );
+
+        expect(respondexSpy).toHaveBeenCalledWith(
+          error,
+          res,
+          {},
+        );
+      });
+
+      it('should call RespondEx.error with custom message', () => {
+        RespondEx.errorByType(
+          'ClientError',
+          res,
+          'A custom message',
+          [],
+        );
+
+        const error = new ApiError(
+          'A custom message',
+          [],
+          400,
+        );
+
+        expect(respondexSpy).toHaveBeenCalledWith(
+          error,
+          res,
+          {},
+        );
+      });
+    });
+
+    describe('Unauthorized', () => {
+      let res;
+      let respondexSpy;
+
+      beforeEach(() => {
+        res = new ResMock();
+        respondexSpy = jest.spyOn(RespondEx, 'error')
+          .mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+      });
+
+      it('should call RespondEx.error with default message', () => {
+        RespondEx.errorByType(
+          'Unauth­orized',
+          res,
+        );
+
+        const error = new ApiError(
+          'Unauthorized',
+          [
+            'Authorization for this resource failed.',
+          ],
+          401,
+        );
+
+        expect(respondexSpy).toHaveBeenCalledWith(
+          error,
+          res,
+          {},
+        );
+      });
+
+      it('should call RespondEx.error with custom message', () => {
+        RespondEx.errorByType(
+          'Unauthorized',
+          res,
+          'A custom message',
+          [],
+        );
+
+        const error = new ApiError(
+          'A custom message',
+          [],
+          401,
+        );
+
+        expect(respondexSpy).toHaveBeenCalledWith(
+          error,
+          res,
+          {},
+        );
+      });
+    });
+
+    describe('Forbidden', () => {
+      let res;
+      let respondexSpy;
+
+      beforeEach(() => {
+        res = new ResMock();
+        respondexSpy = jest.spyOn(RespondEx, 'error')
+          .mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+      });
+
+      it('should call RespondEx.error with default message', () => {
+        RespondEx.errorByType(
+          'Forbidden',
+          res,
+        );
+
+        const error = new ApiError(
+          'Access denied',
+          [
+            'You may not have the right access level to this resource',
+          ],
+          403,
+        );
+
+        expect(respondexSpy).toHaveBeenCalledWith(
+          error,
+          res,
+          {},
+        );
+      });
+
+      it('should call RespondEx.error with custom message', () => {
+        RespondEx.errorByType(
+          'Forbidden',
+          res,
+          'A custom message',
+          [],
+        );
+
+        const error = new ApiError(
+          'A custom message',
+          [],
+          403,
+        );
+
+        expect(respondexSpy).toHaveBeenCalledWith(
+          error,
+          res,
+          {},
+        );
+      });
+    });
+
+    describe('NotFound', () => {
+      let res;
+      let respondexSpy;
+
+      beforeEach(() => {
+        res = new ResMock();
+        respondexSpy = jest.spyOn(RespondEx, 'error')
+          .mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+      });
+
+      it('should call RespondEx.error with default message', () => {
+        RespondEx.errorByType(
+          'NotFound',
+          res,
+        );
+
+        const error = new ApiError(
+          'Resource not found',
+          [
+            'The URL may be wrong',
+          ],
+          404,
+        );
+
+        expect(respondexSpy).toHaveBeenCalledWith(
+          error,
+          res,
+          {},
+        );
+      });
+
+      it('should call RespondEx.error with custom message', () => {
+        RespondEx.errorByType(
+          'NotFound',
+          res,
+          'A custom message',
+          [],
+        );
+
+        const error = new ApiError(
+          'A custom message',
+          [],
+          404,
+        );
+
+        expect(respondexSpy).toHaveBeenCalledWith(
+          error,
+          res,
+          {},
+        );
+      });
+    });
+
+    describe('ServerError', () => {
+      let res;
+      let respondexSpy;
+
+      beforeEach(() => {
+        res = new ResMock();
+        respondexSpy = jest.spyOn(RespondEx, 'error')
+          .mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+      });
+
+      it('should call RespondEx.error with default message', () => {
+        RespondEx.errorByType(
+          'ServerError',
+          res,
+        );
+
+        const error = new ApiError(
+          'A server error has occurred! Please contact the administrator',
+          [
+            'This error is caused by a malfunction in this application',
+          ],
+          404,
+        );
+
+        expect(respondexSpy).toHaveBeenCalledWith(
+          error,
+          res,
+          {},
+        );
+      });
+
+      it('should call RespondEx.error with custom message', () => {
+        RespondEx.errorByType(
+          'ServerError',
+          res,
+          'A custom message',
+          [],
+        );
+
+        const error = new ApiError(
+          'A custom message',
+          [],
+          404,
+        );
+
+        expect(respondexSpy).toHaveBeenCalledWith(
+          error,
+          res,
+          {},
+        );
       });
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import ApiError from '@respondex/apierror';
+
 export default class RespondEx {
   /**
    * @description Send a success response for a created resource.
@@ -5,7 +7,7 @@ export default class RespondEx {
    * @param  {object} data The data to be sent
    * @param  {string} location The URL of the new resource
    * @param  {object} res The express response object
-   * @param  {object} options Object containing options.
+   * @param  {object} options={} Object containing options
    */
   static createdResource(message, data, location, res, options = {}) {
     res.set({
@@ -17,5 +19,95 @@ export default class RespondEx {
       message,
       data,
     });
+  }
+
+  /**
+   * @description Send error response to the serve
+   * @param  {object} error The APIError object of the error that occurred
+   * @param  {object} res The express response object
+   * @param  {object} options={} Object containing options
+   */
+  static error(error, res, options = {}) {
+    res.set({
+      'content-type': options.contentType || 'application/json',
+    });
+    res.status(error.code).json({
+      success: false,
+      message: error.message,
+      possibleCauses: error.possibleCauses || [],
+    });
+  }
+
+  /**
+   * @description Sends error response based on type
+   * @param  {string} type The type of error
+   * @param  {object} res The express response object
+   * @param  {string} message The error message
+   * @param  {object[]} possibleErrors Possible error messages
+   * @param  {object} options={} Object containing options
+   */
+  static errorByType(type, res, message, possibleErrors, options = {}) {
+    switch (type) {
+      case 'ClientError':
+      {
+        const error = new ApiError(
+          message || 'A client error has occurred.',
+          possibleErrors || [
+            'You may not be sending all the information required',
+            'Some of the information may be in the wrong type or format',
+          ],
+          400,
+        );
+        RespondEx.error(error, res, options);
+        break;
+      }
+      case 'Unauth­orized':
+      {
+        const error = new ApiError(
+          message || 'Unauthorized',
+          possibleErrors || [
+            'Authorization for this resource failed.',
+          ],
+          401,
+        );
+        RespondEx.error(error, res, options);
+        break;
+      }
+      case 'Forbidden':
+      {
+        const error = new ApiError(
+          message || 'Access denied',
+          possibleErrors || [
+            'You may not have the right access level to this resource',
+          ],
+          403,
+        );
+        RespondEx.error(error, res, options);
+        break;
+      }
+      case 'NotFound':
+      {
+        const error = new ApiError(
+          message || 'Resource not found',
+          possibleErrors || [
+            'The URL may be wrong',
+          ],
+          404,
+        );
+        RespondEx.error(error, res, options);
+        break;
+      }
+      default:
+      {
+        const error = new ApiError(
+          message || 'A server error has occurred! Please contact the administrator',
+          possibleErrors || [
+            'This error is caused by a malfunction in this application',
+          ],
+        );
+        RespondEx.error(error, res, options);
+        break;
+      }
+    }
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Adds some error response handlers

#### Background context
It is important that users are able to send error responses as well. With this, users will be able to send errors by type without having to worry about the details of the error. Users can also take control and customize their very own error using the `APIError` class.

#### Task completed (detailed list of changes/additions)
- [x] Add the APIError class
- [x] Add the `error` handling method
- [x] Add the `errorByType` handling method
- [x] Update the README to contain information on gow to use the `APIError` class.

#### How can this be manually tested
