### PR TITLE
Add Success Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,44 @@ RespondEx.createdResource(
 );
 ```
 
+**successWithData**: Sends a HTTP response for a successful request with some returned data. Response will contain a 200 status code, message and data in the body.
+
+| Parameters             | Type   | Description                              | Example                                       |
+|------------------------|--------|------------------------------------------|-----------------------------------------------|
+| message                | string | The message to be sent with the response | "Product successfully created."               |
+| data                   | object | Newly created resource data              | { name: "Chair" }                             |
+| res                    | object | The express http response object         |                                               |
+| options (_optional_)   | object | Some extra headers                       | { contentType: "application/json" }           |
+
+#### Example
+```
+RespondEx.successWithData(
+  'Successful sign-in',
+  {
+    name: 'Chair',
+    quantity: 100,
+    description: 'A comfortable seat for your afternoon tea.'
+  },
+  res,
+);
+```
+
+**successWithoutData**: Sends a HTTP response for a successful request without an data. Response will contain a 200 status code and message body.
+
+| Parameters             | Type   | Description                              | Example                                       |
+|------------------------|--------|------------------------------------------|-----------------------------------------------|
+| message                | string | The message to be sent with the response | "Product successfully created."               |
+| res                    | object | The express http response object         |                                               |
+| options (_optional_)   | object | Some extra headers                       | { contentType: "application/json" }           |
+
+#### Example
+```
+RespondEx.successWithData(
+  'Successful sign-in',
+  res,
+);
+```
+
 **error**: Sends a HTTP response error using an instance of the APIError class.
 
 | Parameter             | Type     | Description                              | Example                                       |

--- a/src/__tests__/RespondEx.spec.js
+++ b/src/__tests__/RespondEx.spec.js
@@ -3,7 +3,7 @@ import ApiError from '@respondex/apierror';
 import ResMock from '../__mocks__/ResMock';
 
 describe('RespondEx', () => {
-  describe('createdResource', () => {
+  describe('createdResource()', () => {
     let res;
     let statusSpy;
     let jsonSpy;
@@ -63,7 +63,106 @@ describe('RespondEx', () => {
     });
   });
 
-  describe('error', () => {
+  describe('successWithData()', () => {
+    let res;
+    let statusSpy;
+    let jsonSpy;
+    let setSpy;
+
+    beforeEach(() => {
+      res = new ResMock();
+      statusSpy = jest.spyOn(res, 'status');
+      jsonSpy = jest.spyOn(res, 'json');
+      setSpy = jest.spyOn(res, 'set');
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should set the response type to application/json', () => {
+      RespondEx.successWithData(
+        'Success message',
+        {
+          name: 'Chair',
+          number: 100,
+          description: 'A comfortable chair for your afternoon tea',
+        },
+        res,
+      );
+
+      expect(setSpy).toHaveBeenCalledWith({
+        'content-type': 'application/json',
+      });
+    });
+
+    it('should set response data and code properly', () => {
+      RespondEx.successWithData(
+        'Success message',
+        {
+          name: 'Chair',
+          number: 100,
+          description: 'A comfortable chair for your afternoon tea',
+        },
+        res,
+      );
+
+      expect(statusSpy).toHaveBeenCalledWith(200);
+      expect(jsonSpy).toHaveBeenCalledWith({
+        success: true,
+        message: 'Success message',
+        data: {
+          name: 'Chair',
+          number: 100,
+          description: 'A comfortable chair for your afternoon tea',
+        },
+      });
+    });
+  });
+
+  describe('successWithoutData()', () => {
+    let res;
+    let statusSpy;
+    let jsonSpy;
+    let setSpy;
+
+    beforeEach(() => {
+      res = new ResMock();
+      statusSpy = jest.spyOn(res, 'status');
+      jsonSpy = jest.spyOn(res, 'json');
+      setSpy = jest.spyOn(res, 'set');
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should set the response type to application/json', () => {
+      RespondEx.successWithoutData(
+        'Success message',
+        res,
+      );
+
+      expect(setSpy).toHaveBeenCalledWith({
+        'content-type': 'application/json',
+      });
+    });
+
+    it('should set response data and code properly', () => {
+      RespondEx.successWithoutData(
+        'Success message',
+        res,
+      );
+
+      expect(statusSpy).toHaveBeenCalledWith(200);
+      expect(jsonSpy).toHaveBeenCalledWith({
+        success: true,
+        message: 'Success message',
+      });
+    });
+  });
+
+  describe('error()', () => {
     let res;
     let statusSpy;
     let jsonSpy;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,40 @@ import ApiError from '@respondex/apierror';
 
 export default class RespondEx {
   /**
+   * @description Send a success response with some data.
+   * @param  {string} message The message of the response
+   * @param  {object} data The data to be sent
+   * @param  {object} res The express response object
+   * @param  {object} options={} Object containing options
+   */
+  static successWithData(message, data, res, options = {}) {
+    res.set({
+      'content-type': options.contentType || 'application/json',
+    });
+    res.status(200).json({
+      success: true,
+      message,
+      data,
+    });
+  }
+
+  /**
+   * @description Send a success response without some data.
+   * @param  {string} message The message of the response
+   * @param  {object} res The express response object
+   * @param  {object} options={} Object containing options
+   */
+  static successWithoutData(message, res, options = {}) {
+    res.set({
+      'content-type': options.contentType || 'application/json',
+    });
+    res.status(200).json({
+      success: true,
+      message,
+    });
+  }
+
+  /**
    * @description Send a success response for a created resource.
    * @param  {string} message The message of the response
    * @param  {object} data The data to be sent


### PR DESCRIPTION
#### What does this PR do?
Adds two success response messages

#### Background context
These methods are required to send success responses

#### Task completed (detailed list of changes/additions)
- [x] add success response for data
- [x] add success response without data
- [x] update the readme

#### How can this be manually tested
- Clone the repo and checkout this branch
- Pack the app using `npm pack`
- Point the package at the `tgz` file locally
- Test it against your local test express app.
