### PR TITLE
Add Server Side Error Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ RespondEx.successWithData(
 );
 ```
 
-**error**: Sends a HTTP response error using an instance of the APIError class.
+**error**: Sends a HTTP response error using an instance of the APIError class. This method will also handle unforseen server errors that occur at runtime.
 
 | Parameter             | Type     | Description                              | Example                                       |
 |------------------------|----------|------------------------------------------|-----------------------------------------------|
@@ -102,11 +102,19 @@ RespondEx.successWithData(
 | res                    | object   | The express http response object         |                                               |
 | options (_optional_)   | object   | Some extra headers                       | { contentType: "application/json" }           |
 
-#### Example
+#### Examples
 ```
 import APIError from "@respondex/apierror"
 
 const error = new APIError(...);
+RespondEx.error(
+  error,
+  res,
+);
+```
+The below example would cause a 500 server error response.
+```
+const error = new Error(...);
 RespondEx.error(
   error,
   res,

--- a/src/__tests__/RespondEx.spec.js
+++ b/src/__tests__/RespondEx.spec.js
@@ -214,6 +214,21 @@ describe('RespondEx', () => {
         possibleCauses: [],
       });
     });
+
+    it('should set the status code to 500 with custom possible cases', () => {
+      const error = new Error('Some error');
+
+      RespondEx.error(error, res);
+
+      expect(statusSpy).toHaveBeenCalledWith(500);
+      expect(jsonSpy).toHaveBeenCalledWith({
+        success: false,
+        message: 'A server error has occurred! Please contact the administrator',
+        possibleCauses: [
+          'This error is caused by a malfunction in this application',
+        ],
+      });
+    });
   });
 
   describe('errorByType', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -65,11 +65,15 @@ export default class RespondEx {
     res.set({
       'content-type': options.contentType || 'application/json',
     });
-    res.status(error.code).json({
-      success: false,
-      message: error.message,
-      possibleCauses: error.possibleCauses || [],
-    });
+    if (error.code) {
+      res.status(error.code).json({
+        success: false,
+        message: error.message,
+        possibleCauses: error.possibleCauses || [],
+      });
+    } else {
+      RespondEx.errorByType('ServerError', res);
+    }
   }
 
   /**


### PR DESCRIPTION
#### What does this PR do?
This pull request adds the ability to handle server-side error messages.

#### Background context
This feature is needed to account for cases where a server error occurs during the running of the application. Here is a simple example.
```
someMiddleware(req, res, next) {
    try {
        const x = anUndeclearedvariable;
    } catch (error) {
        RespondEx.error(error, res);
    }
}
```
The above function will throw an error that formerly could not be handled properly by the `error` method.

#### Task completed (detailed list of changes/additions)
- [x] Add native server error handling in error method
- [x] Update documentation
- [x] Update tests

#### How can this be manually tested
- Clone the repo and checkout this branch
- Pack the app using `npm pack`
- Point the package at the `tgz` file locally
- Test it against your local test express app
